### PR TITLE
Refactor: StateMachine header definitions

### DIFF
--- a/include/Minefields/GameContext.h
+++ b/include/Minefields/GameContext.h
@@ -10,11 +10,12 @@ namespace Minefields
 
 using CoordGenerator = std::function<std::pair<int, int>()>;
 
-    enum class Attempted : unsigned char
-    {
-        No,
-        Yes
-    };
+enum class Attempted : unsigned char
+{
+    No,
+    Yes
+};
+
 struct GameContext
 {
     int width = 0;
@@ -29,6 +30,7 @@ struct GameContext
     inline void resetAttemptedShots(GameContext& gameContext)
     {
         gameContext.attemptedShots.assign(gameContext.height, std::vector<Attempted>(gameContext.width, Attempted::No));
-    };
+    }
 
-}; // namespace Minefields
+}; 
+} // namespace Minefields

--- a/include/Minefields/IGameState.h
+++ b/include/Minefields/IGameState.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "GameContext.h"
+
+namespace Minefields
+{
+
+struct State;
+struct GameContext;
+
+using StateUpdateFn = State (*)(GameContext&);
+
+
+struct State
+{
+    StateUpdateFn updateFunction{nullptr};
+};
+
+State stateMainMenuUpdate(GameContext& context);
+State stateOptionsUpdate(GameContext& context);
+State stateQuitUpdate(GameContext& context); 
+
+void runMainLoop();
+
+void clearConsoleBuffer();
+
+} // namespace Minefields


### PR DESCRIPTION
Cleaned up State/StateUpdateFn declarations in StateMachine.h
- Ensured clear separation of responsibilities between GameContext.h and StateMachine.h