### PR TITLE
refactor state: move one round (player+cpu) to statePlayingUpdate

### DIFF
--- a/include/Minefields/States.h
+++ b/include/Minefields/States.h
@@ -15,6 +15,7 @@ struct State
 State stateMainMenuUpdate(GameContext& context);
 State stateOptionsUpdate(GameContext& context);
 State stateQuitUpdate(GameContext& context);
+State statePlayingUpdate(GameContext& context);
 
 void runMainLoop();
 void clearConsoleBuffer();

--- a/src/Minefields/States.cpp
+++ b/src/Minefields/States.cpp
@@ -11,8 +11,6 @@ void clearConsoleBuffer()
     char const* const kClearConsoleBufferCommand = "cls";
     system(kClearConsoleBufferCommand);
 }
-void playTurns(int height, int width, int totalMines, CoordGenerator const& generateCoord);
-void playerTurn(std::vector<std::vector<Cell>>& board, std::vector<std::vector<bool>>& matrix, int width, int height, int& playerMinesLeft, int& cpuMinesLeft);
 
 State stateQuitUpdate(GameContext& context)
 {
@@ -60,6 +58,35 @@ State stateMainMenuUpdate(GameContext& context)
     return context.currentState;
 }
 
+State statePlayingUpdate(GameContext& context)
+{
+    std::vector<std::vector<bool>> matrix(context.height, std::vector<bool>(context.width, false));
+
+    std::cout << "\n===== NEW ROUND =====\n";
+
+    std::cout << "\n--- Player's turn ---\n";
+
+    playerTurn(context.board.grid, matrix, context.width, context.height, context.playerMinesLeft, context.cpuMinesLeft);
+
+    if (context.cpuMinesLeft <= 0)
+    {
+        std::cout << "CPU has no mines left. You win!\n";
+        return {&stateQuitUpdate}; 
+    }
+
+    std::cout << "\n--- CPU's turn ---\n";
+    cpuTurn(context.board.grid, matrix, context.width, context.height, context.playerMinesLeft, context.cpuMinesLeft, context.generateCoord);
+
+    printBoard(context.board.grid);
+    std::cout << "\nMines left - Player: " << context.playerMinesLeft << ", CPU: " << context.cpuMinesLeft << "\n";
+
+    if (context.playerMinesLeft <= 0)
+    {
+        std::cout << "You have no mines left. CPU wins!\n";
+
+        return {&stateQuitUpdate};  
+    }
+}
 void runMainLoop()
 {
     bool quit = false;


### PR DESCRIPTION
Added statePlayingUpdate(GameContext&) to handle a single round:
Player turn
CPU turn
Print board and mines left
Main menu now can transition into Playing.
Kept function signatures the same, only relocated logic.